### PR TITLE
Adding Transform fields to iTDS request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Winterspite/maltego
+module github.com/dreadl0ck/maltego
 
-go 1.18
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/winterspite/maltego
+module github.com/Winterspite/maltego
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dreadl0ck/maltego
+module github.com/winterspite/maltego
 
-go 1.15
+go 1.18

--- a/message.go
+++ b/message.go
@@ -17,9 +17,10 @@ import "encoding/xml"
 
 // RequestMessage models a request.
 type RequestMessage struct {
-	XMLName  xml.Name `xml:"MaltegoTransformRequestMessage"`
-	Entities Entities `xml:"Entities"`
-	Limits   Limits   `xml:"Limits"`
+	XMLName         xml.Name `xml:"MaltegoTransformRequestMessage"`
+	Entities        Entities `xml:"Entities"`
+	Limits          Limits   `xml:"Limits"`
+	TransformFields Fields   `xml:"TransformFields"`
 }
 
 // Limits structure.

--- a/message.go
+++ b/message.go
@@ -17,10 +17,10 @@ import "encoding/xml"
 
 // RequestMessage models a request.
 type RequestMessage struct {
-	XMLName         xml.Name `xml:"MaltegoTransformRequestMessage"`
-	Entities        Entities `xml:"Entities"`
-	Limits          Limits   `xml:"Limits"`
-	TransformFields Fields   `xml:"TransformFields"`
+	XMLName         xml.Name        `xml:"MaltegoTransformRequestMessage"`
+	Entities        Entities        `xml:"Entities"`
+	Limits          Limits          `xml:"Limits"`
+	TransformFields TransformFields `xml:"TransformFields"`
 }
 
 // Limits structure.
@@ -28,4 +28,14 @@ type Limits struct {
 	XMLName   xml.Name `xml:"Limits"`
 	HardLimit string   `xml:"HardLimit,attr"`
 	SoftLimit string   `xml:"SoftLimit,attr"`
+}
+
+type TransformFields struct {
+	Fields []*TransformField `xml:"Field"`
+}
+
+// TransformField structure.
+type TransformField struct {
+	Text string `xml:",chardata"`
+	Name string `xml:"Name,attr"`
 }

--- a/transform.go
+++ b/transform.go
@@ -32,7 +32,7 @@ type ResponseMessage struct {
 	UIMessages UIMessages `xml:"UIMessages"`
 }
 
-// ResponseMessage is a container for maltego entities.
+// Entities is a container for maltego entities.
 type Entities struct {
 	Items []*Entity `xml:"Entity"`
 }


### PR DESCRIPTION
- Allowing someone building a transform server to have access to the Transform fields in a Maltego request.
- Also fixed a random incorrect comment on a variable type.